### PR TITLE
 DRAFT Bug Fix: AutoCompletePlugin in Lexical Playground.  Remove waterfall update - use recommended node transform

### DIFF
--- a/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
+++ b/packages/lexical-playground/src/plugins/AutocompletePlugin/index.tsx
@@ -21,6 +21,7 @@ import {
   COMMAND_PRIORITY_LOW,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_TAB_COMMAND,
+  RootNode,
 } from 'lexical';
 import {useCallback, useEffect} from 'react';
 
@@ -208,7 +209,7 @@ export default function AutocompletePlugin(): JSX.Element | null {
         AutocompleteNode,
         $handleAutocompleteNodeTransform,
       ),
-      editor.registerUpdateListener(handleUpdate),
+      editor.registerNodeTransform(RootNode, handleUpdate),
       editor.registerCommand(
         KEY_TAB_COMMAND,
         $handleKeypressCommand,


### PR DESCRIPTION
## Description

**Current Behavior:**  https://github.com/facebook/lexical/issues/6156
_Steps to Reproduce:_ 

1. Go to Playground, enable autocomplete
2. Start typing a word for example "International". Make sure to pause between letters so HistoryPlugin catches each letter as separate change.
3. Try to CTRL-Z couple of times.
4. In effect Autocomplete stops working, and (TAB) is stuck next to cursor.

**Changes Added**
This PR updates the AutoCompletePlugin within the Lexical Playground to registerNodeTransform for the Root Node and handleUpdates. This avoids incompatibility issues with undo/redo functionality in the HistoryPlugin. 

Closes #6156

## Test plan

### Before

*Insert relevant screenshots/recordings/automated-tests*


### After

*Insert relevant screenshots/recordings/automated-tests*